### PR TITLE
Fixed the wordsize/radix mixup bug. 

### DIFF
--- a/src/main/java/net/praqma/jenkins/memorymap/util/HexUtils.java
+++ b/src/main/java/net/praqma/jenkins/memorymap/util/HexUtils.java
@@ -52,7 +52,7 @@ public class HexUtils {
     }
 
     public static double wordCount(String hexString, int wordSize, String scale) {
-        return HexUtils.getRadix(hexString, wordSize) / (double) HexUtils.scale.get(scale.toLowerCase());
+        return HexUtils.getRadix(hexString, 16) / (double) HexUtils.scale.get(scale.toLowerCase());
     }
 
     public static double byteCount(String hexString, int wordSize, String scale) {

--- a/src/test/java/net/praqma/jenkins/unit/HexUtilsTest.java
+++ b/src/test/java/net/praqma/jenkins/unit/HexUtilsTest.java
@@ -43,13 +43,21 @@ public class HexUtilsTest {
     public ExpectedException thrown = ExpectedException.none();
 
     /**
-     * Test the conversion of the number 1024 to kWords
+     * Test the conversion of the number 1024 to kWords with a few different word sizes
      */
     @Test
     public void wordCountTestKilo() {
+        assertEquals(1023d / 1024, HexUtils.wordCount("3FF", 8, "kilo"), 0);
+        assertEquals(1024d / 1024, HexUtils.wordCount("400", 8, "kilo"), 0);
+        assertEquals(1025d / 1024, HexUtils.wordCount("401", 8, "kilo"), 0);
+
         assertEquals(1023d / 1024, HexUtils.wordCount("3FF", 16, "kilo"), 0);
         assertEquals(1024d / 1024, HexUtils.wordCount("400", 16, "kilo"), 0);
         assertEquals(1025d / 1024, HexUtils.wordCount("401", 16, "kilo"), 0);
+
+        assertEquals(1023d / 1024, HexUtils.wordCount("3FF", 32, "kilo"), 0);
+        assertEquals(1024d / 1024, HexUtils.wordCount("400", 32, "kilo"), 0);
+        assertEquals(1025d / 1024, HexUtils.wordCount("401", 32, "kilo"), 0);
 
     }
 
@@ -76,13 +84,21 @@ public class HexUtilsTest {
     }
 
     /**
-     * Test the conversion of the number 1024 to kBytes
+     * Test the conversion of the number 1024 to kBytes with a few different word sizes
      */
     @Test
     public void byteCountTestKilo() {
+        assertEquals((1023d / 1024) * (8 / 8), HexUtils.byteCount("3FF", 8, "kilo"), 0);
+        assertEquals((1024d / 1024) * (8 / 8), HexUtils.byteCount("400", 8, "kilo"), 0);
+        assertEquals((1025d / 1024) * (8 / 8), HexUtils.byteCount("401", 8, "kilo"), 0);
+
         assertEquals((1023d / 1024) * (16 / 8), HexUtils.byteCount("3FF", 16, "kilo"), 0);
         assertEquals((1024d / 1024) * (16 / 8), HexUtils.byteCount("400", 16, "kilo"), 0);
         assertEquals((1025d / 1024) * (16 / 8), HexUtils.byteCount("401", 16, "kilo"), 0);
+
+        assertEquals((1023d / 1024) * (32 / 8), HexUtils.byteCount("3FF", 32, "kilo"), 0);
+        assertEquals((1024d / 1024) * (32 / 8), HexUtils.byteCount("400", 32, "kilo"), 0);
+        assertEquals((1025d / 1024) * (32 / 8), HexUtils.byteCount("401", 32, "kilo"), 0);
 
     }
 


### PR DESCRIPTION
There is a problem where wordSize is incorrectly used as radix when doing hex to dec conversion. Unfortunately the UnitTest only tested with  wordsize 16, which also happens to be the radix for hexadecimal numbers, so the bug slipped by in all tests. So, I also added a few UnitTests for various word sizes.

Tested on Jenkins with the `gcc-arm-none-eabi-6-2017-q2-update` compiler on a STM32F303 project. Linker command file and map files used in the Jenkins test are attached.
[STM32_map_testfiles.zip](https://github.com/Praqma/memory-map-plugin/files/1190058/STM32_map_testfiles.zip)
